### PR TITLE
Update mmlu.py

### DIFF
--- a/deepeval/benchmarks/mmlu/mmlu.py
+++ b/deepeval/benchmarks/mmlu/mmlu.py
@@ -171,7 +171,10 @@ class MMLU(DeepEvalBaseBenchmark):
             res: MultipleChoiceSchema = model.generate(
                 prompt=prompt, schema=MultipleChoiceSchema
             )
-            prediction = res.answer
+            if isinstance(res, (tuple, list)):
+                prediction = res[0].answer
+            else:
+                prediction = res.answer
         except TypeError:
             prompt += f"\n\n{self.confinement_instructions}"
             prediction = model.generate(prompt)
@@ -210,7 +213,10 @@ class MMLU(DeepEvalBaseBenchmark):
             responses: List[MultipleChoiceSchema] = model.batch_generate(
                 prompts=prompts, schemas=[MultipleChoiceSchema for i in prompts]
             )
-            predictions = [res.answer for res in responses]
+            if isinstance(responses, (tuple, list)):
+                predictions = [res[0].answer for res in responses]
+            else:
+                predictions = [res.answer for res in responses]
         except TypeError:
             prompts = [
                 prompt


### PR DESCRIPTION
This PR fixes an issue where the model.generate() method returns a tuple or list of results instead of a single object. Previously, accessing res.answer directly caused a TypeError because res was a tuple containing the MultipleChoiceSchema object. The fix safely checks if the result is a tuple or list and extracts the first element before accessing .answer. This ensures compatibility with different return types from the model’s generate() method and prevents runtime errors.

Let me know if you want it more detailed or more concise!